### PR TITLE
Fix endless generation after level up

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,6 +319,7 @@
         collectibles = [];
         wormhole = null;
         levelReached++;
+        generateGameObjects(true);
         showLevelUpMessage(`Entering Zone ${gameLevel}!`);
     }
 


### PR DESCRIPTION
## Summary
- ensure objects spawn immediately after entering a new level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672b80c1a88320b4a82bbba17a9d51