### PR TITLE
Fix wormhole spawn location

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,10 @@
 
         if (score > LEVEL_UP_SCORE * gameLevel && !wormhole) {
             sound.wormholeAppear();
-            wormhole = new Wormhole(screenWidth / 2, cameraY - 50);
+            // Spawn the wormhole relative to the player's current position
+            // rather than the camera position. This prevents it from appearing
+            // off screen when the camera lagged behind the player.
+            wormhole = new Wormhole(screenWidth / 2, player.y - screenHeight * 0.5);
         }
         
         if (levelUpMessage.timer > 0) levelUpMessage.timer -= deltaTime;


### PR DESCRIPTION
## Summary
- spawn wormhole relative to player so it always appears on screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672d293e548320baae5e086d8feb91