### PR TITLE
Update service worker cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'galaxy-grapple-v1';
+// Update the cache name to invalidate old caches on new deployments
+const CACHE_NAME = 'galaxy-grapple-v2';
 const URLS_TO_CACHE = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache to `galaxy-grapple-v2` so old caches are cleared automatically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879e10833308320810dcea70c8ba130